### PR TITLE
docs.rs: Only build for Windows (and target it by default)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ repository = "https://github.com/Traverse-Research/amd-ext-d3d-rs"
 description = "Rust bindings for AMD's DirectX12 modified PIX3 RGP markers"
 include = ["src", "LICENSE"]
 
+[package.metadata.docs.rs]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+]
+
 [dependencies]
 anyhow = "1.0.3"
 libloading = "0.8"


### PR DESCRIPTION
It seems updates to `windows` crates post `0.57` (i.e. after our `0.3.0` release) have extra `cfg(windows)` in place that prevent building documentation on all non-Windows platforms:

https://docs.rs/crate/amd-ext-d3d/0.3.1/builds/1291996
https://docs.rs/crate/amd-ext-d3d/0.4.0/builds/2537501

Limit the documentation to only build on a few architectures for Windows MSVC.  Besides that, when no `default-target` is specified the first element of `targets` is used, placing users directly on documentation for the Windows "variant" of this crate.
